### PR TITLE
Texture sync october

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -175,6 +175,7 @@ function App() {
 		volo_mesh.position.z = -2;
 		scene.add(volo_mesh);
 		
+		// Note: this is called from vol_player.mjs
 		VolPlayer.set_frame_callback(function (frameNumber, key, vert, uvs, ind) {
 			volo_geometry.index.array = ind.slice();
 			volo_geometry.attributes.position.array = vert.slice();
@@ -183,6 +184,12 @@ function App() {
 			volo_geometry.index.needsUpdate = true;
 			volo_geometry.attributes.position.needsUpdate = true;
 			volo_geometry.attributes.uv.needsUpdate = true;
+
+			/*
+			volo_geometry.setAttribute('position', new THREE.BufferAttribute(vert, 3 ) ); // f32
+			volo_geometry.setAttribute('uv', new THREE.BufferAttribute(uvs, 2 ) );        // f32
+			volo_geometry.index = new THREE.BufferAttribute(ind, 1 );                     // u16
+			*/
 		});
 		VolPlayer.start();
 	}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,7 @@ function App() {
 			} );
 		volo_mesh = new THREE.Mesh(volo_geometry, mat);
 		volo_mesh.name = 'Vologram';
-		volo_mesh.scale.x = 1;
+		volo_mesh.scale.x = -1; // Reverse on x for "California" from "ainrofilaC"
 		volo_mesh.scale.y = 1;
 		volo_mesh.scale.z = 1;
 		volo_mesh.position.z = -2;
@@ -177,6 +177,7 @@ function App() {
 		
 		// Note: this is called from vol_player.mjs
 		VolPlayer.set_frame_callback(function (frameNumber, key, vert, uvs, ind) {
+			/* Original code.
 			volo_geometry.index.array = ind.slice();
 			volo_geometry.attributes.position.array = vert.slice();
 			volo_geometry.attributes.uv.array = uvs.slice();
@@ -184,12 +185,13 @@ function App() {
 			volo_geometry.index.needsUpdate = true;
 			volo_geometry.attributes.position.needsUpdate = true;
 			volo_geometry.attributes.uv.needsUpdate = true;
-
-			/*
+			*/
+			
+			// This should fix the buffer overrun issues with some volograms, but might add a small
+			// allocation overhead at runtime.
 			volo_geometry.setAttribute('position', new THREE.BufferAttribute(vert, 3 ) ); // f32
 			volo_geometry.setAttribute('uv', new THREE.BufferAttribute(uvs, 2 ) );        // f32
 			volo_geometry.index = new THREE.BufferAttribute(ind, 1 );                     // u16
-			*/
 		});
 		VolPlayer.start();
 	}

--- a/src/web_vol_lib/vol_av.mjs
+++ b/src/web_vol_lib/vol_av.mjs
@@ -31,8 +31,10 @@ export function set_video_frame_callback(callback) {
         return;
     }
 
-    video_frame_callback = function () {
-        callback( Math.trunc(video.currentTime * fps) );
+		// Note: 'metadata' is only supported in some browsers, but essential for good video texture sync.
+		// Otherwise use this callback; `callback( Math.trunc(video.currentTime * fps));`
+    video_frame_callback = (now, metadata) => {
+        callback( Math.floor( metadata.mediaTime * fps ) );
         if (is_playing) {
             video.requestVideoFrameCallback( video_frame_callback );
         }

--- a/src/web_vol_lib/vol_av.mjs
+++ b/src/web_vol_lib/vol_av.mjs
@@ -18,8 +18,8 @@ export function open(url, options) {
     }
 
 	video.autoplay = options?.autoplay ?? false;
-	video.muted = options?.muted ?? true; // Must be true for play without page interaction: https://goo.gl/xX8pDD
-	video.loop = options?.loop ?? true;
+	video.muted = options?.muted ?? false;  // Allow audio with vologram, but requires a page gesture to be detected first. This is also required on most browsers for any muted playback.
+    video.loop = options?.loop ?? true;
 	video.preload = options?.preload ?? true;
     video.src = url;
     fps = options?.fps ?? fps;
@@ -39,9 +39,11 @@ export function set_video_frame_callback(callback) {
             video.requestVideoFrameCallback( video_frame_callback );
         }
     }
-} 
+}
 
-export function start() {
+// Note(Anton): we need to capture a gesture to start playback (especially with audio).
+// There is probably a more elegant way to do this, because it requires a click into space first at the moment.
+document.onclick = function() {
     if (video == null) {
         console.warn('video is not initialised, call init() first');
         return;
@@ -50,6 +52,18 @@ export function start() {
     video.play();
     is_playing = true;
     video.requestVideoFrameCallback( video_frame_callback );
+}
+
+// Original function here (replaced by document.onclick for now).
+export function start() {
+    /*if (video == null) {
+        console.warn('video is not initialised, call init() first');
+        return;
+    }
+
+    video.play();
+    is_playing = true;
+    video.requestVideoFrameCallback( video_frame_callback );*/
 }
 
 export function resume() {


### PR DESCRIPTION
Changes made in PR

* Reversed x scale on vologram geometry so "California" on t-shirt reads the right way around.
* Changed video callback to the metadata extension version since its 100% in sync after testing, and the default one is not.
* Changed the buffer update from a slice() copy to a new buffer creation, which should help the buffer overrun issues reported on some volograms, and possibly also mesh update issues.
* Unmuted the audio by default so you can hear recorded audio.
* Added a mouse click callback so that browsers don't complain about auto-playing video and audio.

Testing done

* Brave, Chrome, Ubuntu and Windows 10. ( I think it's better to abandon browsers not supporting the new video extension than have bad sync everywhere ). _Let them use Chrome_
* Tested turning everything on and off to isolate the key bits of code to change.

Blockers and Issues

* Right now you load the vologram, then need to click into the space before it pops in visually. There is probably a nicer way to handle this, and e.g. capture it during the button clicking but I'm out of depth with web stuff here.
* If I tab in and out the rendering of that background grid blows up and the character is rendered in lines mode. I guess this is an issue with three.js not handling switching between lines and polygons nicely. Suggest just replacing the background grid thing with a texture of a grid on 6 planes.

![image](https://user-images.githubusercontent.com/1935602/194874225-c548e7e9-116a-491a-aef8-42ac55b56392.png)
